### PR TITLE
feat(process): expose processor and json formatter

### DIFF
--- a/graph_builder.ts
+++ b/graph_builder.ts
@@ -1,4 +1,4 @@
-import { Node, SourceMapGraph } from "./types";
+import { Node } from "./types";
 import { Logger } from "./utils";
 
 function sumLines(obj: { [key: string]: { count: number } }) {
@@ -52,7 +52,7 @@ export function buildGraph(
   >,
   sourceToBundles: { [sourceName: string]: Set<string> },
   logger: Logger
-): SourceMapGraph {
+) {
   const nodes: Node[] = [];
 
   logger.info("Building graph between bundles.");

--- a/graph_builder.ts
+++ b/graph_builder.ts
@@ -1,4 +1,4 @@
-import { Node } from "./types";
+import { Node, SourceMapGraph } from "./types";
 import { Logger } from "./utils";
 
 function sumLines(obj: { [key: string]: { count: number } }) {
@@ -52,7 +52,7 @@ export function buildGraph(
   >,
   sourceToBundles: { [sourceName: string]: Set<string> },
   logger: Logger
-) {
+): SourceMapGraph {
   const nodes: Node[] = [];
 
   logger.info("Building graph between bundles.");

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 const httpServer = require("http-server");
 const openPort = require("openport");
 import { processSourceMaps } from "./process";
+import { formatProcessedSourceMaps } from "./utils";
 import * as path from "path";
 import * as meow from "meow";
 import * as opn from "opn";
@@ -60,16 +61,7 @@ if (cli.flags["demo"]) {
     logLevel: cli.flags["verbose"] || cli.flags["v"] ? "verbose" : "silent"
   });
 
-  const stringifedData = JSON.stringify({
-    graph: processed.graph,
-    sourceFiles: processed.sourceFiles,
-    bundleFileStats: [...processed.bundleFileStats],
-    outputFiles: processed.outputFiles,
-    groupedBundleStats: [...processed.groupedBundleStats],
-    perFileStats: [...processed.perFileStats],
-    sourceFileLinesGroupedByCommonBundle:
-      processed.sourceFileLinesGroupedByCommonBundle
-  });
+  const stringifedData = formatProcessedSourceMaps(processed);
 
   if (cli.flags["stdout"] || cli.flags["o"]) {
     console.log(stringifedData);

--- a/process.ts
+++ b/process.ts
@@ -10,7 +10,9 @@ import {
   LogLevels,
   BundleToSources,
   SourceFileLinesGroupedByCommonBundle,
-  PerFileStats
+  PerFileStats,
+  SourceFileToGrouped,
+  SourceMapProcessorResults
 } from "./types";
 import {
   Logger,
@@ -123,7 +125,7 @@ function extractHitInto(sourceFiles: SourceFiles, sourcePath: string) {
 export function processSourceMaps(
   bundleSourceMaps: string[],
   opts: { logLevel: LogLevels } = { logLevel: "silent" }
-) {
+): SourceMapProcessorResults {
   opts.logLevel = opts.logLevel || "silent";
 
   const logger = new Logger(opts);
@@ -135,7 +137,7 @@ export function processSourceMaps(
   const bundleToSources: BundleToSources = new Map();
 
   const perFileStats: PerFileStats = new Map();
-  const sourceFileToGrouped = new Map<
+  const sourceFileToGrouped: SourceFileToGrouped = new Map<
     string,
     { [key: string]: { count: number; files: number } }
   >();

--- a/process.ts
+++ b/process.ts
@@ -137,10 +137,7 @@ export function processSourceMaps(
   const bundleToSources: BundleToSources = new Map();
 
   const perFileStats: PerFileStats = new Map();
-  const sourceFileToGrouped: SourceFileToGrouped = new Map<
-    string,
-    { [key: string]: { count: number; files: number } }
-  >();
+  const sourceFileToGrouped: SourceFileToGrouped = new Map();
 
   if (bundleSourceMaps.length === 0) {
     logger.error("Fatal Error: no source maps passed :(");

--- a/types.ts
+++ b/types.ts
@@ -31,6 +31,26 @@ export interface Node {
   inBundleFiles?: string[];
 }
 
+export interface SourceMapGraph {
+  nodes: Node[];
+  links: { source: string; target: string; strength: number }[];
+}
+
+export interface SourceMapProcessorResults {
+  graph: SourceMapGraph;
+  sourceFiles: SourceFiles;
+  perFileStats: PerFileStats;
+  sourceFileLinesGroupedByCommonBundle: SourceFileLinesGroupedByCommonBundle;
+  bundleFileStats: BundleToSources;
+  outputFiles: string[];
+  groupedBundleStats: SourceFileToGrouped;
+}
+
+export type SourceFileToGrouped = Map<
+  string,
+  { [key: string]: { count: number; files: number } }
+>;
+
 export type SourceToBundles = { [source: string]: Set<string> };
 export type LineHitMap = Map<string, { from: string[]; count: number }>;
 export type SourceFiles = {

--- a/utils.ts
+++ b/utils.ts
@@ -24,7 +24,7 @@ export function hashBundlesToKey(files: string[]) {
 
 export function formatProcessedSourceMaps(
   processed: SourceMapProcessorResults
-): string {
+) {
   return JSON.stringify({
     graph: processed.graph,
     sourceFiles: processed.sourceFiles,

--- a/utils.ts
+++ b/utils.ts
@@ -1,4 +1,4 @@
-import { LogLevels, SourceTrack } from "./types";
+import { LogLevels, SourceTrack, SourceMapProcessorResults } from "./types";
 import * as chalk from "chalk";
 
 const WEBPACK_MATCHER = /\/\/ WEBPACK FOOTER \/\/\n\/\/\s+(.*)/m;
@@ -20,6 +20,21 @@ export function hashToFileAndLineNumber(hash: string) {
 
 export function hashBundlesToKey(files: string[]) {
   return Array.from(files).sort().join(HASH_SPLITTER);
+}
+
+export function formatProcessedSourceMaps(
+  processed: SourceMapProcessorResults
+): string {
+  return JSON.stringify({
+    graph: processed.graph,
+    sourceFiles: processed.sourceFiles,
+    bundleFileStats: [...processed.bundleFileStats],
+    outputFiles: processed.outputFiles,
+    groupedBundleStats: [...processed.groupedBundleStats],
+    perFileStats: [...processed.perFileStats],
+    sourceFileLinesGroupedByCommonBundle:
+      processed.sourceFileLinesGroupedByCommonBundle
+  });
 }
 
 /**


### PR DESCRIPTION
* externalize `processSourceMaps` for "public api" use
* add return types for `processSourceMap`
* make serializer reusable and "public api" use