### PR TITLE
fix: Bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bundle-buddy",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "dependencies": {
     "chalk": "^2.0.1",
     "globby": "^6.1.0",


### PR DESCRIPTION
This bumps the package.json version, we will need a new npm release.