### PR TITLE
Fit rippleChart better

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -221,10 +221,13 @@ svg {
   padding-left: 24px;
   width: 100%;
   background: white;
-  max-height: 30vh;
-  padding-bottom: 30px;
-  position: fixed;
+  height: 30vh;
+  padding-bottom: 10px;
+  position: sticky;
   border-top: solid 1px var(--grey800);
+}
+.bottom-panel.paper {
+  box-shadow: none;
 }
 
 .App-header h1 {
@@ -635,7 +638,7 @@ td {
 } */
 
 .Table {
-  width: 100%;
+  width: calc(100% - 16px);
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-collapse: collapse;
   position: relative;


### PR DESCRIPTION
Often I see the ripple chart cropped and I can't see the rest of it.. 

example:
<img width="1430" alt="image" src="https://github.com/samccone/bundle-buddy/assets/39191/bbeb3268-aebc-488e-881a-8cb641736a32">


This adjusted CSS keeps a 30vh height by default but if the svg chart needs more height.. at least the normal page scroll will allow you to show all of it.

and: got rid of box-shadow cuz it doesn't play well.

driveby: weirdly the 100% width doesn't play well with a scrollbar on my machine. dunno why. (I got a trackpad AND a mouse). so.. adjustment for that too.